### PR TITLE
Fix policy argument for relationship setup

### DIFF
--- a/src/devices/composite_device.py
+++ b/src/devices/composite_device.py
@@ -70,9 +70,21 @@ class CompositeDevice(Device):
         if worker not in self.workers:
             self.workers.append(worker)
             self.log_info(f"Added worker {worker.nameShort()} to {self.nameShort()}'s pool.")
-            self.add_relationship(worker, "controller_for", initial_trust=0.7, policy_id="default_task_policy") 
-            if hasattr(worker, 'add_relationship'): 
-                worker.add_relationship(self, "work_for_me", initial_trust=0.7, policy_id="default_task_policy") 
+            # Establish bidirectional task-management relationships using the
+            # 'policy' parameter expected by Device.add_relationship.
+            self.add_relationship(
+                worker,
+                "controller_for",
+                initial_trust=0.7,
+                policy="default_task_policy",
+            )
+            if hasattr(worker, 'add_relationship'):
+                worker.add_relationship(
+                    self,
+                    "work_for_me",
+                    initial_trust=0.7,
+                    policy="default_task_policy",
+                )
 
     def _delegate_to_worker(self, sub_task_type: str, original_job_details: Dict, 
                               required_capability: str,

--- a/src/run_scenario_simulation.py
+++ b/src/run_scenario_simulation.py
@@ -118,8 +118,14 @@ def _initialize_simulation_environment(
         device2 = devices_map.get(dev2_name)
 
         if device1 and device2 and rel_type:
-            device1.add_relationship(device2, rel_type, policy_id=policy_identifier) 
-            logger_instance.log_info("InitEnv", f"Added relationship: {dev1_name} --{rel_type}--> {dev2_name} (Policy/ID: {policy_identifier or 'None'})")
+            # Device.add_relationship expects the policy object or ID via the
+            # 'policy' parameter. Passing 'policy_id' causes a TypeError.
+            device1.add_relationship(device2, rel_type, policy=policy_identifier)
+            logger_instance.log_info(
+                "InitEnv",
+                f"Added relationship: {dev1_name} --{rel_type}--> {dev2_name}"
+                f" (Policy/ID: {policy_identifier or 'None'})",
+            )
         else:
             logger_instance.log_warning("InitEnv", f"Could not establish relationship due to missing devices or type: {rel_data}")
 


### PR DESCRIPTION
## Summary
- fix incorrect `policy_id` parameter usage when adding device relationships
- ensure composite devices establish task policies correctly

## Testing
- `python main.py high_load_case --duration 10`

------
https://chatgpt.com/codex/tasks/task_e_6840380fed74832298cdecff567ac3ba

## Summary by Sourcery

Fix relationship setup by replacing the deprecated `policy_id` argument with `policy` in all `add_relationship` calls to prevent TypeError and ensure task policies are applied correctly during composite device initialization and simulation environment setup.

Bug Fixes:
- Correct the parameter name for `add_relationship` from `policy_id` to `policy` to avoid TypeError during relationship creation.

Enhancements:
- Update composite devices to establish bidirectional task-management relationships using the `policy` parameter.
- Adjust simulation initialization to pass policies via the `policy` argument and refine the logging call formatting.